### PR TITLE
Fixed test for third task for GroupBy 

### DIFF
--- a/tests/task3/group_by.cpp
+++ b/tests/task3/group_by.cpp
@@ -73,7 +73,7 @@ static_assert(
       < ToTuple
       , Take
         < 4
-        , GroupBy<FalseOP, Iterate<Starred, int>>
+        , GroupBy<IsSame, Iterate<Starred, int>>
         >
       >
     >

--- a/tests/task3/group_by.cpp
+++ b/tests/task3/group_by.cpp
@@ -61,6 +61,11 @@ struct FalseOP {
   constexpr static bool Value = false;
 };
 
+template<class L, class R>
+struct IsSame {
+  constexpr static bool Value = std::is_same_v<L, R>;
+};
+
 static_assert(
   std::same_as
   < ToTuple
@@ -82,6 +87,6 @@ static_assert(
 );
 
 
-int main() { 
+int main() {
   return 0;
 }

--- a/tests/task3/group_by.cpp
+++ b/tests/task3/group_by.cpp
@@ -56,11 +56,6 @@ static_assert(
 template<class T>
 using Starred = T*;
 
-template<class, class>
-struct FalseOP {
-  constexpr static bool Value = false;
-};
-
 template<class L, class R>
 struct IsSame {
   constexpr static bool Value = std::is_same_v<L, R>;


### PR DESCRIPTION
FalseOp metafunction didn't meet the requirements of equivalence relation, so I replace it with IsSame.